### PR TITLE
Load API keys from env and update Notion docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
 # clipopera_assets
+
+This repository stores 3D assets and a demo GLAM try-on script.
+
+## Setup
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the local try-on script:
+
+```bash
+python glam_tryon.py
+```
+
+It posts the example images to the GLAM API and prints the result URL. Set
+`GLAM_API_KEY` in your environment or `.env` file before running.
+
+Serverless usage is provided in `api/glam_tryon.py` as an example. The `render.yaml` file defines deployment settings for Render.
+
+## 📤 ClipOpera Notion Upload Guide
+
+Use the `create_notion_page.py` script to send project data to your Notion workspace.
+
+### ✅ Environment Setup
+
+Make sure you’ve defined the following in your `.env` file:
+
+```dotenv
+NOTION_TOKEN=your-secret-token
+NOTION_DATABASE_ID=your-notion-database-id
+GLAM_API_KEY=your-glam-key-here
+```
+
+You can also set these as environment variables directly.
+
+### 🚀 Run the Notion Script
+
+From the root of your project:
+
+```bash
+python create_notion_page.py \
+  --project "ClipOpera AI Portal" \
+  --status "In Progress" \
+  --link "https://clipopera.com" \
+  --budget 2500 \
+  --drive "https://drive.google.com/drive/folders/your-folder-id" \
+  --webmaster "GPT-Webmaster" \
+  --codex "PenAI Assistant" \
+  --gpts "clipbot_id,jetmode_ai" \
+  --library "/path/to/gpt_library" \
+  --registry "/path/to/models.json"
+```
+
+### 📡 API Usage (Optional)
+
+You can also POST to the Flask server if it’s running:
+
+```bash
+curl -X POST http://localhost:5000/run-script \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project": "ClipOpera AI Portal",
+    "status": "Queued",
+    "link": "https://clipopera.com",
+    "drive": "https://drive.google.com/...",
+    "budget": 2500
+  }'
+```
+
+### 🧪 Testing
+
+```bash
+python -m py_compile create_notion_page.py glam_tryon.py api/glam_tryon.py
+```
+
+```bash
+black --check create_notion_page.py glam_tryon.py api/glam_tryon.py
+```
+
+> ❗ Make sure your environment variables are set before running these scripts.
+
+Need help setting up your Notion integration? Let me know!

--- a/api/glam_tryon.py
+++ b/api/glam_tryon.py
@@ -1,0 +1,37 @@
+import os
+from http.server import BaseHTTPRequestHandler
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover
+    load_dotenv = lambda: None
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        media_url = "https://images.squarespace-cdn.com/..."
+        garment_url = "https://images.squarespace-cdn.com/..."
+        load_dotenv()
+        glam_api_key = os.getenv("GLAM_API_KEY")
+        if not glam_api_key:
+            self.send_error(500, "GLAM_API_KEY must be set")
+            return
+
+        headers = {"Content-Type": "application/json", "X-API-Key": glam_api_key}
+
+        payload = {
+            "mask_type": "overall",
+            "media_url": media_url,
+            "garment_url": garment_url,
+        }
+
+        r = requests.post(
+            "https://api.glam.ai/api/v1/tryon", headers=headers, json=payload
+        )
+
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(r.content)

--- a/create_notion_page.py
+++ b/create_notion_page.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import os
+import argparse
+from typing import Dict
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - fallback if python-dotenv not installed
+    load_dotenv = lambda: None  # type: ignore
+
+try:
+    from notion_client import Client
+except ImportError:  # pragma: no cover - ensures helpful error if dependency missing
+    Client = None  # type: ignore
+
+
+def build_properties(args: argparse.Namespace) -> Dict[str, dict]:
+    props: Dict[str, dict] = {
+        "Name": {"title": [{"text": {"content": args.project}}]},
+        "Status": {"rich_text": [{"text": {"content": args.status}}]},
+        "Link": {"url": args.link},
+        "Budget": {"number": args.budget},
+    }
+    if args.drive:
+        props["Drive"] = {"url": args.drive}
+    if args.webmaster:
+        props["Webmaster"] = {"rich_text": [{"text": {"content": args.webmaster}}]}
+    if args.codex:
+        props["Codex"] = {"rich_text": [{"text": {"content": args.codex}}]}
+    if args.gpts:
+        props["GPTs"] = {"rich_text": [{"text": {"content": args.gpts}}]}
+    if args.library:
+        props["Library"] = {"rich_text": [{"text": {"content": args.library}}]}
+    if args.registry:
+        props["Registry"] = {"rich_text": [{"text": {"content": args.registry}}]}
+    return props
+
+
+def main() -> None:
+    load_dotenv()
+    token = os.getenv("NOTION_TOKEN")
+    db_id = os.getenv("NOTION_DATABASE_ID")
+    if not token or not db_id:
+        raise EnvironmentError("NOTION_TOKEN and NOTION_DATABASE_ID must be set")
+
+    parser = argparse.ArgumentParser(description="Create a Notion project page")
+    parser.add_argument("--project", required=True, help="Project name")
+    parser.add_argument("--status", required=True, help="Current status")
+    parser.add_argument("--link", required=True, help="Project link")
+    parser.add_argument("--budget", type=int, required=True, help="Budget amount")
+    parser.add_argument("--drive", help="Google Drive folder URL")
+    parser.add_argument("--webmaster", help="Webmaster name")
+    parser.add_argument("--codex", help="Codex assistant")
+    parser.add_argument("--gpts", help="Comma-separated GPT IDs")
+    parser.add_argument("--library", help="Path to GPT library")
+    parser.add_argument("--registry", help="Path to models registry")
+    args = parser.parse_args()
+
+    if Client is None:
+        raise ImportError("notion-client is required to run this script")
+
+    client = Client(auth=token)
+    props = build_properties(args)
+    client.pages.create(parent={"database_id": db_id}, properties=props)
+    print("Notion page created successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/glam_tryon.py
+++ b/glam_tryon.py
@@ -1,0 +1,50 @@
+import os
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover
+    load_dotenv = lambda: None
+
+# Your Squarespace image URLs
+MEDIA_URL = (
+    "https://images.squarespace-cdn.com/content/67e4029aea1fb67dfe0dbfda/"
+    "1f3b81df-616d-4a89-b7c3-43bf3e285fe2/model.png?content-type=image%2Fpng"
+)
+GARMENT_URL = (
+    "https://images.squarespace-cdn.com/content/67e4029aea1fb67dfe0dbfda/"
+    "90e8be9d-10f8-40f6-b1a8-1a4740513447/shirt.png?content-type=image%2Fpng"
+)
+
+load_dotenv()
+GLAM_API_KEY = os.getenv("GLAM_API_KEY")
+if not GLAM_API_KEY:
+    raise EnvironmentError("GLAM_API_KEY must be set")
+
+# Request headers
+headers = {
+    "Content-Type": "application/json",
+    "X-API-Key": GLAM_API_KEY,
+}
+
+# Request payload
+json_data = {
+    "mask_type": "overall",
+    "media_url": MEDIA_URL,
+    "garment_url": GARMENT_URL,
+}
+
+# Send the try-on request
+response = requests.post(
+    "https://api.glam.ai/api/v1/tryon", headers=headers, json=json_data
+)
+
+# Handle response
+if response.ok:
+    result = response.json()
+    print("✅ Try-On Success!")
+    print("🖼️ Result URL:", result.get("result_url"))
+else:
+    print("❌ Try-On Failed:", response.status_code)
+    print(response.text)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,37 @@
+services:
+  - type: web
+    name: clipopera-backend
+    env: python
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "gunicorn app:app"
+    envVars:
+      - key: FLASK_ENV
+        value: production
+      - key: NOTION_TOKEN
+        sync: false
+      - key: DISCORD_WEBHOOK_URL
+        sync: false
+      - key: SERVICE_ACCOUNT_FILE
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: GOOGLE_DRIVE_FOLDER_ID
+        sync: false
+    autoDeploy: true
+
+deployHook:
+  type: github
+  repo: clipopera2025/clipopera_assets
+  branch: main
+  autoDeploy: true
+
+staticSites:
+  - name: clipopera-assets
+    buildCommand: ""
+    staticPublishPath: "public"
+    indexDocument: index.html
+    errorDocument: 404.html
+    routes:
+      - type: rewrite
+        source: /
+        destination: /index.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+notion-client
+python-dotenv


### PR DESCRIPTION
## Summary
- secure GLAM try-on scripts by reading the API key from the environment
- flesh out README with full Notion upload guide
- document additional env vars and testing

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile glam_tryon.py api/glam_tryon.py create_notion_page.py`
- `black --check glam_tryon.py api/glam_tryon.py create_notion_page.py`


------
https://chatgpt.com/codex/tasks/task_e_684157e5dbc88323ba9bd415e5845cb3