### PR TITLE
Add Google Apps Script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # clipopera_assets
+
+This repository contains assets for the ClipOpera project, including 3D model files and planning documents.
+
+## Google Apps Script
+
+You can use the provided `SoraForm.gs` script to create a simple Google Form that triggers OpenAI's Sora video generation API.
+
+### Steps
+1. Visit [Google Apps Script](https://script.google.com/) and create a new project.
+2. Delete any code in `Code.gs` and replace it with the contents of `SoraForm.gs`.
+3. Update `YOUR_OPENAI_API_KEY` with your OpenAI API key.
+4. Save the project and run the `createSoraForm` function to generate the form.
+
+When the form is submitted with "Generate Video?" set to "Yes," it will send a request to the OpenAI API to start video generation.
+

--- a/SoraForm.gs
+++ b/SoraForm.gs
@@ -1,0 +1,48 @@
+function createSoraForm() {
+  const form = FormApp.create('Sora Video Generator');
+
+  form.addTextItem()
+      .setTitle('Your Name')
+      .setRequired(true);
+
+  form.addTextItem()
+      .setTitle('Prompt Description')
+      .setHelpText('Describe your cinematic scene')
+      .setRequired(true);
+
+  form.addMultipleChoiceItem()
+      .setTitle('Generate Video?')
+      .setChoiceValues(['Yes', 'No'])
+      .setRequired(true);
+
+  Logger.log('Form URL: ' + form.getEditUrl());
+}
+
+function onFormSubmit(e) {
+  const responses = e.namedValues;
+  const shouldGenerate = responses['Generate Video?'][0] === 'Yes';
+
+  if (!shouldGenerate) return;
+
+  const prompt = responses['Prompt Description'][0];
+
+  const payload = {
+    prompt: prompt,
+    width: 480,
+    height: 480,
+    n_seconds: 20,
+    model: "sora"
+  };
+
+  const options = {
+    method: 'POST',
+    contentType: 'application/json',
+    headers: {
+      Authorization: 'Bearer YOUR_OPENAI_API_KEY'
+    },
+    payload: JSON.stringify(payload)
+  };
+
+  UrlFetchApp.fetch('https://api.openai.com/v1/video/generations/jobs', options);
+}
+


### PR DESCRIPTION
## Summary
- add Google Apps Script `SoraForm.gs`
- document how to use the script in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c0d1fa488323985ef17df2123bb1