### PR TITLE
Fix html lint workflow path

### DIFF
--- a/.github/workflows/html-lint.yml
+++ b/.github/workflows/html-lint.yml
@@ -1,0 +1,22 @@
+name: HTML Lint
+
+on:
+  push:
+    paths:
+      - 'docs/**/*.html'
+      - '.github/workflows/html-lint.yml'
+  pull_request:
+    paths:
+      - 'docs/**/*.html'
+      - '.github/workflows/html-lint.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Run htmlhint
+        run: npx -y htmlhint 'docs/**/*.html'


### PR DESCRIPTION
## Summary
- update GitHub Actions step to use npx htmlhint
- lint docs/**/*.html recursively

## Testing
- `npx -y htmlhint 'docs/**/*.html'`


------
https://chatgpt.com/codex/tasks/task_e_6845da4c97508323992176a24bc9daa7